### PR TITLE
Initial working version of logstash-integration plugin after bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ spec/fixtures/certs/generated
 Gemfile.lock
 .ruby-version
 .ci
+.idea
+.bundle
+vendor

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Need help? Try the https://discuss.elastic.co/c/logstash discussion forum.
 
 ## Developing
 
-### 1. Plugin Developement and Testing
+### 1. Plugin Development and Testing
 
 #### Code
 - To get started, you'll need JRuby with the Bundler gem installed.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-:plugin: aws
+:plugin: logstash
 :type: integration
 :no_codec:
 
@@ -19,15 +19,12 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 include::{include_path}/plugin_header.asciidoc[]
 
-:link-logstash-output: pass:n[{logstash-ref}/plugins-outputs-logstash.html[Logstash Output Plugin]]
-:link-logstash-input: pass:n[{logstash-ref}/plugins-inputs-logstash.html[Logstash Input Plugin]]
-
 ==== Description
 
 The Logstash Integration Plugin provides integrated plugins for sending events from one Logstash to another:
 
-* {link-logstash-output}
-* {link-logstash-input}
+* {logstash-ref}/plugins-outputs-logstash.html[Logstash Output Plugin]
+* {logstash-ref}/plugins-inputs-logstash.html[Logstash Input Plugin]
 
 [id="plugins-{type}s-{plugin}-concepts"]
 ===== High-level concepts

--- a/docs/input-logstash.asciidoc
+++ b/docs/input-logstash.asciidoc
@@ -106,29 +106,26 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting                            |Input type        |Required
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>> |No
-| <<plugins-{type}s-{plugin}-port>> |<<number,number>> |Yes
-| <<plugins-{type}s-{plugin}-username>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
-| <<plugins-{type}s-{plugin}-ssl_enabled>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-port>> |<<number,number>> |Yes
 | <<plugins-{type}s-{plugin}-ssl_certificate>> | <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-ssl_client_authentication>> | <<string,string>>, one of `["none", "optional", "required"]`|No
+| <<plugins-{type}s-{plugin}-ssl_cipher_suites>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-ssl_enabled>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ssl_handshake_timeout>>|<<number,number>>|No
 | <<plugins-{type}s-{plugin}-ssl_key>> | <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_password>> | <<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_path>> | <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_key_passphrase>> | <<password,password>>|No
-| <<plugins-{type}s-{plugin}-ssl_verification_mode>> | <<string,string>>, one of `["certificate"]`|No
-| <<plugins-{type}s-{plugin}-ssl_client_authentication>> | <<string,string>>, one of `["none", "optional", "required"]`|No
+| <<plugins-{type}s-{plugin}-ssl_supported_protocols>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-username>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
 input plugins.
 
 &nbsp;
-
-// Variables for re-use in per-option docs
-:prohibit-ssl-disabled-effective: Cannot be combined with configurations that disable SSL
-:prohibit-ssl-disabled-explicit: pass:n[Cannot be combined with <<plugins-{type}s-{plugin}-ssl_enabled, `+ssl_enabled => false+`>>.]
-:prohibit-ssl-client-authentication-none: pass:n[Cannot be combined with <<plugins-{type}s-{plugin}-ssl_client_authentication, `+ssl_client_authentication => none+`>>.]
 
 [id="plugins-{type}s-{plugin}-host"]
 ===== `host`
@@ -139,14 +136,6 @@ input plugins.
 Specify which interface to listen on by providing its ip address.
 By default, this input listens on all available interfaces.
 
-[id="plugins-{type}s-{plugin}-port"]
-===== `port`
-
-* Value type is a <<number,number>> port
-* There is no default value
-
-Specify which port to listen on.
-
 [id="plugins-{type}s-{plugin}-password"]
 ===== `password`
 
@@ -156,26 +145,13 @@ Specify which port to listen on.
 Password for password-based authentication.
 Requires <<plugins-{type}s-{plugin}-username>>.
 
-[id="plugins-{type}s-{plugin}-username"]
-===== `username`
+[id="plugins-{type}s-{plugin}-port"]
+===== `port`
 
-* Value type is <<string,string>>
-* There is no default value for this setting.
+* Value type is a <<number,number>> port
+* There is no default value
 
-Username for password-based authentication.
-When this input plugin is configured with a `username`, it also requires a <<plugins-{type}s-{plugin}-password>>, and any upstream <<plugins-outputs-logstash>> must also be configured with a matching `username`/`password` pair.
-
-NOTE: when SSL is disabled, credentials will be transmitted in clear-text.
-
-[id="plugins-{type}s-{plugin}-ssl_enabled"]
-===== `ssl_enabled`
-
-* Value type is <<boolean,boolean>>
-* Default value is `true`
-
-SSL is enabled by default, which requires configuring this plugin to present its <<plugins-{type}s-{plugin}-config-ssl-identity, identity>>.
-
-You can disable SSL with `+ssl_enabled => false+`.
+Specify which port to listen on.
 
 [id="plugins-{type}s-{plugin}-ssl_certificate"]
 ===== `ssl_certificate`
@@ -183,7 +159,6 @@ You can disable SSL with `+ssl_enabled => false+`.
 * Value type is <<path,path>>
 * There is no default value for this setting.
 * When present, <<plugins-{type}s-{plugin}-ssl_key>> and <<plugins-{type}s-{plugin}-ssl_key_passphrase>> are also required.
-* {prohibit-ssl-disabled-effective}
 
 Path to a PEM-encoded certificate or certificate chain with which to identify this plugin to connecting clients.
 The certificate _SHOULD_ include identity claims about the ip address or hostname that clients use to establish a connection.
@@ -193,94 +168,10 @@ The certificate _SHOULD_ include identity claims about the ip address or hostnam
 
 * Value type is a list of <<path,path>>s
 * There is no default value for this setting.
-* {prohibit-ssl-disabled-effective}
-* {prohibit-ssl-client-authentication-none}
 
+Cannot be used with `+ssl_client_authentication => "none"+`.
 One or more PEM-encoded files defining certificate authorities for use in client authentication.
-
 This setting can be used to _override_ the system trust store for verifying the SSL certificate presented by clients.
-
-[id="plugins-{type}s-{plugin}-ssl_key"]
-===== `ssl_key`
-
-* Value type is <<path,path>>
-* There is no default value for this setting.
-* Required when connection identity is configured with <<plugins-{type}s-{plugin}-ssl_certificate>>
-* {prohibit-ssl-disabled-effective}
-
-A path to a PEM-encoded _encrypted_ PKCS8 SSL certificate key.
-
-[id="plugins-{type}s-{plugin}-ssl_keystore_password"]
-===== `ssl_keystore_password`
-
-* Value type is <<password,password>>
-* There is no default value for this setting.
-* Required when connection identity is configured with <<plugins-{type}s-{plugin}-ssl_keystore_path>>
-* {prohibit-ssl-disabled-effective}
-
-Password for the <<plugins-{type}s-{plugin}-ssl_keystore_path>>
-
-[id="plugins-{type}s-{plugin}-ssl_keystore_path"]
-===== `ssl_keystore_path`
-
-* Value type is <<path,path>>
-* There is no default value for this setting.
-* When present, <<plugins-{type}s-{plugin}-ssl_keystore_password>> is also required.
-* {prohibit-ssl-disabled-effective}
-
-A path to a JKS- or PKCS12-formatted keystore with which to identify this plugin to {es}.
-
-[id="plugins-{type}s-{plugin}-ssl_key_passphrase"]
-===== `ssl_key_passphrase`
-
-* Value type is <<password,password>>
-* There is no default value for this setting.
-* Required when connection identity is configured with <<plugins-{type}s-{plugin}-ssl_certificate>>
-* {prohibit-ssl-disabled-effective}
-
-A password or passphrase of the <<plugins-{type}s-{plugin}-ssl_key>>.
-
-[id="plugins-{type}s-{plugin}-ssl_truststore_path"]
-===== `ssl_truststore_path`
-
-* Value type is <<path,path>>
-* There is no default value for this setting.
-* When present, <<plugins-{type}s-{plugin}-ssl_truststore_password>> is required.
-* {prohibit-ssl-disabled-effective}
-* {prohibit-ssl-verify-none}
-
-A path to JKS- or PKCS12-formatted keystore where trusted certificates are located.
-
-This setting can be used to _override_ the system trust store for verifying the SSL certificate presented by {es}.
-
-[id="plugins-{type}s-{plugin}-ssl_truststore_password"]
-===== `ssl_truststore_password`
-
-* Value type is <<password,password>>
-* There is no default value for this setting.
-* Required when connection trust is configured with <<plugins-{type}s-{plugin}-ssl_truststore_path>>
-* {prohibit-ssl-disabled-effective}
-
-Password for the <<plugins-{type}s-{plugin}-ssl_truststore_path>>.
-
-[id="plugins-{type}s-{plugin}-ssl_verification_mode"]
-===== `ssl_verification_mode`
-
-* Value type is <<string,string>>
-* There is only one currently-supported mode:
-** `certificate`: verifies that a certificate provided by the client is signed by a trusted authority (CA), is within its valid date range, and that the client has possession of the associated key, but does _not_ perform hostname validation.
-// NOTE: `ssl_verification_mode => full` is pending upstream support, but when it arrives it will look like:
-////
-** `full`: fully validates the certificate as in `certificate` mode, and also validates that the client's outbound IP address is represented in the certificate's identity claims for `subject` and/or `subjectAltName`.
-////
-* The default value is `certificate`.
-* {prohibit-ssl-disabled-effective}
-* {prohibit-ssl-client-authentication-none}
-
-When <<plugins-{type}s-{plugin}-ssl_client_authentication>> causes a client to present a certificate, this setting controls how that certificate is verified.
-
-NOTE: Client identity is not typically validated using SSL because the receiving server only has access to the client's outbound-ip, which is not always constant and is frequently not represented in the certificate's subject or subjectAltNames extensions.
-For more information, see https://www.rfc-editor.org/rfc/rfc2818#section-3.1[RFC2818 § 3.2 (HTTP over TLS -- Client Identity)]
 
 [id="plugins-{type}s-{plugin}-ssl_client_authentication"]
 ===== `ssl_client_authentication`
@@ -291,9 +182,102 @@ For more information, see https://www.rfc-editor.org/rfc/rfc2818#section-3.1[RFC
 ** `required`: require a valid certificate from the client that is signed by a trusted certificate authority
 * Default value is `"none"`
 
-By default the server doesn't do any client authentication.
+By default, the server doesn't proceed client authentication.
 This means that connections from clients are _private_ when SSL is enabled, but that this input will allow SSL connections from _any_ client.
 If you wish to configure this plugin to reject connections from untrusted hosts, you will need to configure this plugin to authenticate clients, and may also need to configure its <<plugins-{type}s-{plugin}-config-ssl-trust, source of trust>>.
+
+[id="plugins-{type}s-{plugin}-ssl_cipher_suites"]
+===== `ssl_cipher_suites`
+
+* Value type is <<array,array>>
+* Default value is `['TLS_AES_256_GCM_SHA384', 'TLS_AES_128_GCM_SHA256', 'TLS_CHACHA20_POLY1305_SHA256', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256', 'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256', 'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256', 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256', 'TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384', 'TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384', 'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256', 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256']`
+
+The list of cipher suites to use, listed by priorities.
+This default list applies for OpenJDK 11.0.14 and higher.
+For older JDK versions, the default list includes only suites supported by that version.
+For example, the ChaCha20 family of ciphers is not supported in older versions.
+
+[id="plugins-{type}s-{plugin}-ssl_enabled"]
+===== `ssl_enabled`
+
+* Value type is <<boolean,boolean>>
+* Default value is `true`
+
+SSL is enabled by default, which requires configuring this plugin to present its <<plugins-{type}s-{plugin}-config-ssl-identity, identity>>.
+
+You can disable SSL with `+ssl_enabled => false+`. When disabled, setting any `ssl_*` configuration causes configuration failure.
+
+[id="plugins-{type}s-{plugin}-ssl_handshake_timeout"]
+===== `ssl_handshake_timeout`
+
+* Value type is <<number,number>>
+* Default value is `10000`
+
+Time in milliseconds for SSL handshake timeout
+
+[id="plugins-{type}s-{plugin}-ssl_key"]
+===== `ssl_key`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+* Required when connection identity is configured with <<plugins-{type}s-{plugin}-ssl_certificate>>
+
+A path to a PEM-encoded _encrypted_ PKCS8 SSL certificate key.
+
+[id="plugins-{type}s-{plugin}-ssl_keystore_password"]
+===== `ssl_keystore_password`
+
+* Value type is <<password,password>>
+* There is no default value for this setting.
+* Required when connection identity is configured with <<plugins-{type}s-{plugin}-ssl_keystore_path>>
+
+Password for the <<plugins-{type}s-{plugin}-ssl_keystore_path>>
+
+[id="plugins-{type}s-{plugin}-ssl_keystore_path"]
+===== `ssl_keystore_path`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+* When present, <<plugins-{type}s-{plugin}-ssl_keystore_password>> is also required.
+
+A path to a JKS- or PKCS12-formatted keystore with which to identify this plugin to {es}.
+
+[id="plugins-{type}s-{plugin}-ssl_key_passphrase"]
+===== `ssl_key_passphrase`
+
+* Value type is <<password,password>>
+* There is no default value for this setting.
+* Required when connection identity is configured with <<plugins-{type}s-{plugin}-ssl_certificate>>
+
+A password or passphrase of the <<plugins-{type}s-{plugin}-ssl_key>>.
+
+[id="plugins-{type}s-{plugin}-username"]
+===== `username`
+
+* Value type is <<string,string>>
+* There is no default value for this setting.
+
+Username for HTTP Basic Authentication.
+When this input plugin is configured with a `username`, it also requires a <<plugins-{type}s-{plugin}-password>>, and any upstream <<plugins-outputs-logstash>> must also be configured with a matching `username`/`password` pair.
+
+NOTE: when SSL is disabled, credentials will be transmitted in clear-text.
+
+[id="plugins-{type}s-{plugin}-ssl_supported_protocols"]
+===== `ssl_supported_protocols`
+
+* Value type is <<string,string>>
+* Allowed values are: `'TLSv1.1'`, `'TLSv1.2'`, `'TLSv1.3'`
+* Default depends on the JDK being used. With up-to-date Logstash, the default is `['TLSv1.2', 'TLSv1.3']`.
+`'TLSv1.1'` is not considered secure and is only provided for legacy applications.
+
+List of allowed SSL/TLS versions to use when establishing a connection to the HTTP endpoint.
+
+For Java 8 `'TLSv1.3'` is supported  only since **8u262** (AdoptOpenJDK), but requires that you set the
+`LS_JAVA_OPTS="-Djdk.tls.client.protocols=TLSv1.3"` system property in Logstash.
+
+NOTE: If you configure the plugin to use `'TLSv1.1'` on any recent JVM, such as the one packaged with Logstash,
+the protocol is disabled by default and needs to be enabled manually by changing `jdk.tls.disabledAlgorithms` in
+the *$JDK_HOME/conf/security/java.security* configuration file. That is, `TLSv1.1` needs to be removed from the list.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/output-logstash.asciidoc
+++ b/docs/output-logstash.asciidoc
@@ -106,30 +106,25 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting                            |Input type        |Required
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>> |Yes
-| <<plugins-{type}s-{plugin}-port>> |<<number,number>> |Yes
-| <<plugins-{type}s-{plugin}-username>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-port>> |<<number,number>> |Yes
 | <<plugins-{type}s-{plugin}-ssl_enabled>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ssl_certificate>> | <<path,path>>|No
+| <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |list of <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_key>> | <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_path>> | <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_password>> | <<password,password>>|No
+| <<plugins-{type}s-{plugin}-ssl_supported_protocols>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl_truststore_path>> | <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_truststore_password>> | <<password,password>>|No
-| <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-ssl_verification_mode>> | <<string,string>>, one of `["full", "none"]`|No
+| <<plugins-{type}s-{plugin}-username>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
 input plugins.
 
 &nbsp;
-
-// Variables for re-use in per-option docs
-:prohibit-ssl-disabled-effective: Cannot be combined with configurations that disable SSL.
-:prohibit-ssl-disabled-explicit: pass:n[Cannot be combined with <<plugins-{type}s-{plugin}-ssl_enabled, `+ssl_enabled => false+`>>.]
-:prohibit-ssl-verification-mode-none: pass:n[Cannot be combined with <<plugins-{type}s-{plugin}-ssl_verification_mode, `+ssl_verification_mode => none+`>>.]
-
 
 [id="plugins-{type}s-{plugin}-host"]
 ===== `host`
@@ -149,6 +144,128 @@ NOTE: when using SSL, the server that responds must present a certificated with 
 
 Specify which port to connect to.
 
+[id="plugins-{type}s-{plugin}-password"]
+===== `password`
+
+* Value type is <<password,password>>
+* There is no default value for this setting.
+* Required when <<plugins-{type}s-{plugin}-username>> is configured.
+
+Password for password-based authentication.
+
+When the downstream input plugin is configured with a `username` and `password`, you must also configure upstream outputs with a matching `username`/`password` pair.
+
+[id="plugins-{type}s-{plugin}-ssl_enabled"]
+===== `ssl_enabled`
+
+* Value type is <<boolean,boolean>>
+* Default value is `true`
+
+Logstash-to-Logstash communication is secured by default.
+When the downstream input plugin disables SSL, it must also be disabled here.
+
+You can disable SSL with `+ssl_enabled => false+`. When disabled, setting any `ssl_*` configuration causes configuration failure.
+
+[id="plugins-{type}s-{plugin}-ssl_certificate"]
+===== `ssl_certificate`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+* When present, <<plugins-{type}s-{plugin}-ssl_key>> is also required.
+
+Path to a PEM-encoded certificate or certificate chain with which to identify this plugin to connecting clients.
+The certificate _SHOULD_ include identity claims about the ip address or hostname that clients use to establish a connection.
+
+[id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
+===== `ssl_certificate_authorities`
+
+* Value type is a <<path,path>>
+* There is no default value for this setting.
+
+One or more PEM-encoded files defining certificate authorities for use in client authentication.
+This setting can be used to _override_ the system trust store for verifying the SSL certificate presented by clients.
+Cannot be combined with `+ssl_verification_mode => none+`.
+
+[id="plugins-{type}s-{plugin}-ssl_key"]
+===== `ssl_key`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+* Required when connection identity is configured with <<plugins-{type}s-{plugin}-ssl_certificate>>
+
+A path to an PEM-encoded _unencrypted_ PKCS8 SSL certificate key.
+
+[id="plugins-{type}s-{plugin}-ssl_keystore_path"]
+===== `ssl_keystore_path`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+* When present, <<plugins-{type}s-{plugin}-ssl_keystore_password>> is also required.
+
+A path to a JKS- or PKCS12-formatted keystore with which to identify this plugin to the downstream input.
+The provided identity will be used if the downstream input enables <<plugins-{type}s-{plugin}-config-ssl-trust,SSL client authentication>>.
+
+[id="plugins-{type}s-{plugin}-ssl_keystore_password"]
+===== `ssl_keystore_password`
+
+* Value type is <<password,password>>
+* There is no default value for this setting.
+* Required when connection identity is configured with <<plugins-{type}s-{plugin}-ssl_keystore_path>>
+
+Password for the <<plugins-{type}s-{plugin}-ssl_keystore_path>>
+
+[id="plugins-{type}s-{plugin}-ssl_supported_protocols"]
+===== `ssl_supported_protocols`
+
+* Value type is <<string,string>>
+* Allowed values are: `'TLSv1.1'`, `'TLSv1.2'`, `'TLSv1.3'`
+* Default depends on the JDK being used. With up-to-date Logstash, the default is `['TLSv1.2', 'TLSv1.3']`.
+`'TLSv1.1'` is not considered secure and is only provided for legacy applications.
+
+List of allowed SSL/TLS versions to use when establishing a connection to the HTTP endpoint.
+
+For Java 8 `'TLSv1.3'` is supported  only since **8u262** (AdoptOpenJDK), but requires that you set the
+`LS_JAVA_OPTS="-Djdk.tls.client.protocols=TLSv1.3"` system property in Logstash.
+
+NOTE: If you configure the plugin to use `'TLSv1.1'` on any recent JVM, such as the one packaged with Logstash,
+the protocol is disabled by default and needs to be enabled manually by changing `jdk.tls.disabledAlgorithms` in
+the *$JDK_HOME/conf/security/java.security* configuration file. That is, `TLSv1.1` needs to be removed from the list.
+
+[id="plugins-{type}s-{plugin}-ssl_truststore_path"]
+===== `ssl_truststore_path`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+* When present, <<plugins-{type}s-{plugin}-ssl_truststore_path>> is also required.
+Cannot be combined with `+ssl_verification_mode => none+`.
+
+A path to a JKS- or PKCS12-formatted truststore with which to validate the identity claims of the downstream input.
+The provided identity will be used if the downstream input enables <<plugins-{type}s-{plugin}-config-ssl-trust,SSL client authentication>>.
+
+[id="plugins-{type}s-{plugin}-ssl_truststore_password"]
+===== `ssl_truststore_password`
+
+* Value type is <<password,password>>
+* There is no default value for this setting.
+* Required when connection identity is configured with <<plugins-{type}s-{plugin}-ssl_truststore_path>>
+
+Password for the <<plugins-{type}s-{plugin}-ssl_truststore_path>>
+
+[id="plugins-{type}s-{plugin}-ssl_verification_mode"]
+===== `ssl_verification_mode`
+
+* Value type is <<string,string>>
+* There is only one currently-supported mode:
+** `full`: verifies that a certificate provided by the client has an identity claim matching <<plugins-{type}s-{plugin}-host>>, is signed by a trusted authority (CA), is within its valid date range, and that the client has possession of the associated key.
+** `none`: performs no validation of the presented certificate
+
+* The default value is `full`.
+
+When <<plugins-{type}s-{plugin}-ssl_client_authentication>> causes a client to present a certificate, this setting controls how that certificate is verified.
+
+NOTE: Client identity is not typically validated using SSL because the receiving server only has access to the client's outbound-ip, which is not always constant and is frequently not represented in the certificate's subject or subjectAltNames extensions.
+For more information, see https://www.rfc-editor.org/rfc/rfc2818#section-3.1[RFC2818 § 3.2 (HTTP over TLS -- Client Identity)]
+
 [id="plugins-{type}s-{plugin}-username"]
 ===== `username`
 
@@ -162,117 +279,7 @@ When the downstream input plugin is configured with a `username` and `password`,
 
 NOTE: when SSL is disabled, credentials will be transmitted in clear-text.
 
-[id="plugins-{type}s-{plugin}-ssl_enabled"]
-===== `ssl_enabled`
+[id="plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]
 
-* Value type is <<boolean,boolean>>
-* Default value is `true`
-
-Logstash-to-Logstash communication is secured by default.
-When the downstream input plugin disables SSL, it must also be disabled here.
-
-You can disable SSL with `+ssl_enabled => false+`.
-
-[id="plugins-{type}s-{plugin}-password"]
-===== `password`
-
-* Value type is <<password,password>>
-* There is no default value for this setting.
-* Required when <<plugins-{type}s-{plugin}-username>> is configured.
-
-Password for password-based authentication.
-
-When the downstream input plugin is configured with a `username` and `password`, you must also configure upstream outputs with a matching `username`/`password` pair.
-
-[id="plugins-{type}s-{plugin}-ssl_certificate"]
-===== `ssl_certificate`
-
-* Value type is <<path,path>>
-* There is no default value for this setting.
-* When present, <<plugins-{type}s-{plugin}-ssl_key>> is also required.
-* {prohibit-ssl-disabled-effective}
-
-Path to a PEM-encoded certificate or certificate chain with which to identify this plugin to connecting clients.
-The certificate _SHOULD_ include identity claims about the ip address or hostname that clients use to establish a connection.
-
-[id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
-===== `ssl_certificate_authorities`
-
-* Value type is a <<path,path>>
-* There is no default value for this setting.
-* {prohibit-ssl-disabled-effective}
-* {prohibit-ssl-verification-mode-none}
-
-One or more PEM-encoded files defining certificate authorities for use in client authentication.
-
-This setting can be used to _override_ the system trust store for verifying the SSL certificate presented by clients.
-
-[id="plugins-{type}s-{plugin}-ssl_key"]
-===== `ssl_key`
-
-* Value type is <<path,path>>
-* There is no default value for this setting.
-* Required when connection identity is configured with <<plugins-{type}s-{plugin}-ssl_certificate>>
-* {prohibit-ssl-disabled-effective}
-
-A path to an PEM-encoded _unencrypted_ PKCS8 SSL certificate key.
-
-[id="plugins-{type}s-{plugin}-ssl_keystore_password"]
-===== `ssl_keystore_password`
-
-* Value type is <<password,password>>
-* There is no default value for this setting.
-* Required when connection identity is configured with <<plugins-{type}s-{plugin}-ssl_keystore_path>>
-* {prohibit-ssl-disabled-effective}
-
-Password for the <<plugins-{type}s-{plugin}-ssl_keystore_path>>
-
-[id="plugins-{type}s-{plugin}-ssl_keystore_path"]
-===== `ssl_keystore_path`
-
-* Value type is <<path,path>>
-* There is no default value for this setting.
-* When present, <<plugins-{type}s-{plugin}-ssl_keystore_password>> is also required.
-* {prohibit-ssl-disabled-effective}
-
-A path to a JKS- or PKCS12-formatted keystore with which to identify this plugin to the downstream input.
-The provided identity will be used if the downstream input enables <<plugins-{type}s-{plugin}-config-ssl-trust,SSL client authentication>>.
-
-[id="plugins-{type}s-{plugin}-ssl_truststore_password"]
-===== `ssl_truststore_password`
-
-* Value type is <<password,password>>
-* There is no default value for this setting.
-* Required when connection identity is configured with <<plugins-{type}s-{plugin}-ssl_truststore_path>>
-* {prohibit-ssl-disabled-effective}
-
-Password for the <<plugins-{type}s-{plugin}-ssl_truststore_path>>
-
-[id="plugins-{type}s-{plugin}-ssl_truststore_path"]
-===== `ssl_truststore_path`
-
-* Value type is <<path,path>>
-* There is no default value for this setting.
-* When present, <<plugins-{type}s-{plugin}-ssl_truststore_path>> is also required.
-* {prohibit-ssl-disabled-effective}
-* {prohibit-ssl-verification-mode-none}
-
-A path to a JKS- or PKCS12-formatted truststore with which to validate the identity claims of the downstream input.
-The provided identity will be used if the downstream input enables <<plugins-{type}s-{plugin}-config-ssl-trust,SSL client authentication>>.
-
-
-[id="plugins-{type}s-{plugin}-ssl_verification_mode"]
-===== `ssl_verification_mode`
-
-* Value type is <<string,string>>
-* There is only one currently-supported mode:
-** `full`: verifies that a certificate provided by the client has an identity claim matching <<plugins-{type}s-{plugin}-host>>, is signed by a trusted authority (CA), is within its valid date range, and that the client has possession of the associated key.
-** `none`: performs no validation of the presented certificate
-
-* The default value is `full`.
-* {prohibit-ssl-disabled-effective}
-
-When <<plugins-{type}s-{plugin}-ssl_client_authentication>> causes a client to present a certificate, this setting controls how that certificate is verified.
-
-NOTE: Client identity is not typically validated using SSL because the receiving server only has access to the client's outbound-ip, which is not always constant and is frequently not represented in the certificate's subject or subjectAltNames extensions.
-For more information, see https://www.rfc-editor.org/rfc/rfc2818#section-3.1[RFC2818 § 3.2 (HTTP over TLS -- Client Identity)]
+:default_codec!:

--- a/lib/logstash/outputs/logstash.rb
+++ b/lib/logstash/outputs/logstash.rb
@@ -1,11 +1,11 @@
 # encoding: utf-8
 
-require 'logstash/inputs/base'
+require 'logstash/outputs/base'
 require 'logstash/namespace'
 
 require "logstash/plugin_mixins/plugin_factory_support"
 
-class LogStash::Outputs::Logstash < LogStash::Inputs::Base
+class LogStash::Outputs::Logstash < LogStash::Outputs::Base
   include LogStash::PluginMixins::PluginFactorySupport
 
   config_name "logstash"
@@ -120,14 +120,14 @@ class LogStash::Outputs::Logstash < LogStash::Inputs::Base
       fail(LogStash::ConfigurationError, 'SSL identity can be configured with EITHER `ssl_certificate` OR `ssl_keystore_*`, but not both')
     elsif @ssl_certificate
       return {
-        'client_cert' => @ssl_certificate,
-        'client_key'  => @ssl_key || fail("`ssl_key` is REQUIRED when `ssl_certificate` is provided"),
+        'ssl_certificate' => @ssl_certificate,
+        'ssl_key'  => @ssl_key || fail("`ssl_key` is REQUIRED when `ssl_certificate` is provided"),
       }
     elsif @ssl_keystore_path
       return {
-        'keystore' => @ssl_keystore_path,
-        'keystore_type' => keystore_type(@ssl_keystore_path),
-        'keystore_password' => @ssl_keystore_password || fail("`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided"),
+        'ssl_keystore_path' => @ssl_keystore_path,
+        'ssl_keystore_type' => keystore_type(@ssl_keystore_path),
+        'ssl_keystore_password' => @ssl_keystore_password || fail("`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided"),
       }
     else
       return {}
@@ -143,13 +143,13 @@ class LogStash::Outputs::Logstash < LogStash::Inputs::Base
       elsif @ssl_certificate_authorities&.any?
         fail(LogStash::ConfigurationError, 'SSL Certificate Authorities cannot be configured when `ssl_verification_mode => none`') if @ssl_verification_mode == 'none'
 
-        trust_options['cacert'] = @ssl_certificate_authorities.first
+        trust_options['ssl_certificate_authorities'] = @ssl_certificate_authorities.first
       elsif @ssl_truststore_path
         fail(LogStash::ConfigurationError, 'SSL Truststore cannot be configured when `ssl_verification_mode => none`') if @ssl_verification_mode == 'none'
 
-        trust_options['truststore'] = @ssl_truststore_path
-        trust_options['truststore_type'] = keystore_type(@ssl_truststore_path)
-        trust_options['truststore_password'] = @ssl_truststore_password || fail("`truststore_password` is REQUIRED when `ssl_truststore_path` is provided")
+        trust_options['ssl_truststore_path'] = @ssl_truststore_path
+        trust_options['ssl_truststore_path'] = keystore_type(@ssl_truststore_path)
+        trust_options['ssl_truststore_password'] = @ssl_truststore_password || fail("`ssl_truststore_password` is REQUIRED when `ssl_truststore_path` is provided")
       end
     end
   end

--- a/logstash-integration-logstash.gemspec
+++ b/logstash-integration-logstash.gemspec
@@ -1,4 +1,4 @@
-INTEGRATION_LOGSTASH_VERSION = File.read(File.expand_path(File.join(File.dirname(__FILE__), "VERSION"))).strip unless defined?(INTEGRATION_AWS_VERSION)
+INTEGRATION_LOGSTASH_VERSION = File.read(File.expand_path(File.join(File.dirname(__FILE__), "VERSION"))).strip unless defined?(INTEGRATION_LOGSTASH_VERSION)
 
 Gem::Specification.new do |s|
   s.name            = "logstash-integration-logstash"
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]
   s.email           = "info@elastic.co"
-  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.homepage        = "https://www.elastic.co/logstash"
   s.platform        = "java"
   s.metadata        = {
     "logstash_plugin" => "true",
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     ).join(",")
   }
 
-  s.require_paths   = ["lib", "vendor/jar-dependencies"]
+  s.require_paths   = %w[lib vendor/jar-dependencies]
   s.files           = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "VERSION", "docs/**/*", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb"]
   s.test_files      = s.files.grep(%r{^(test|spec|features)/})
 
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-mixin-plugin_factory_support", "~> 1.0"
   s.add_runtime_dependency "logstash-codec-json_lines", "~> 3.1"
 
-  s.add_runtime_dependency "logstash-input-http"
-  s.add_runtime_dependency "logstash-output-http"
+  s.add_runtime_dependency "logstash-input-http", ">= 3.7.2"  # some params renamed, such as `cacert` to `ssl_certificate_authorities`, do not exist in older versions
+  s.add_runtime_dependency "logstash-output-http", ">= 5.6.0"
 
   s.add_development_dependency "logstash-devutils"
   s.add_development_dependency "rspec-collection_matchers"

--- a/spec/full_transmission_spec.rb
+++ b/spec/full_transmission_spec.rb
@@ -37,7 +37,7 @@ describe 'Logstash Output -> Input complete transmission' do
   # requires: input_plugin (a Logstash input plugin)
   # optional: concurrency (default: 1)
   # optional: batch_size (default: 125)
-  # provides: output_events (an arrray of Events)
+  # provides: output_events (an array of Events)
   shared_context 'transmission' do
     let(:concurrency) { defined?(super) ? super() : 8 }
     let(:batch_size) { defined?(super) ? super() : 125 }


### PR DESCRIPTION
### Description
This change applies recent `http-input/output` and `http-mixin-client` SSL standardization changes. It also updates the documentations where asciidoc re-usable variable removed, may break doc build failure, alphabetically re-ordered and some missed params added.

### TODOs
I have run both input and output plugins and tested data send/receive but couldn't cover all tests.

- [x] manual codec provided and got error, non-related params tested
- [ ] SSL related test
- [ ] add some unit test cases?